### PR TITLE
Added Watcher that watches over the chunk directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,22 @@
-FROM golang:1.23-alpine AS builder
+# FROM golang:1.23-alpine AS builder
+
+
+# COPY go.mod go.sum ./
+# RUN go mod download
+
+# COPY . .
+# RUN go build -o /goback main.go
+
+FROM debian:stable-slim
 
 WORKDIR /app
 
-COPY go.mod go.sum ./
-RUN go mod download
-
 COPY . .
-RUN go build -o /goback main.go
 
-FROM alpine:3.18
-
-RUN apk add --no-cache openssh sqlite && \
+RUN apt-get intsall openssh && \
     mkdir -p /app/private /app/.data && \
     [ ! -f /app/private/id_rsa ] && ssh-keygen -t rsa -b 4096 -f /app/private/id_rsa -N "" || true
 
-COPY --from=builder /goback /usr/local/bin/goback
+COPY goback /usr/local/bin/goback
 
 CMD ["goback"]

--- a/server/worker.go
+++ b/server/worker.go
@@ -20,14 +20,17 @@ type Worker struct {
 func (w *Worker) StartSFTPServer() {
 	wd, err := os.Getwd()
 	if err != nil {
-		log.Fatalf("Cannot get the working directory of %v", err)
+		log.Fatalf("Cannot get the working directory: %v", err)
 	}
+
 	rsaPath := wd + "/private/id_rsa"
 
-	err = utils.WatchDirectory("./.data/")
+	// Start directory watcher
+	watcher, err := utils.WatchDirectory(wd + "/.data")
 	if err != nil {
-		log.Fatalf("Error while creating watcher %v", err)
+		log.Fatalf("Error while creating watcher: %v", err)
 	}
+	defer watcher.Close() // Ensure the watcher is cleaned up on server shutdown
 
 	sftpServer := New(w.Ip, rsaPath, w.Port)
 	w.sftpServer = &sftpServer
@@ -38,4 +41,7 @@ func (w *Worker) StartSFTPServer() {
 			log.Fatalf("Worker SFTP server failed to listen: %v", err)
 		}
 	}()
+
+	// Keep the worker process alive
+	select {}
 }

--- a/utils/watcher.go
+++ b/utils/watcher.go
@@ -2,44 +2,46 @@ package utils
 
 import (
 	"fmt"
-	"log"
 
+	"github.com/charmbracelet/log"
 	"github.com/fsnotify/fsnotify"
 )
 
-func WatchDirectory(directory string) error {
+func WatchDirectory(directory string) (*fsnotify.Watcher, error) {
 	watcher, err := fsnotify.NewWatcher()
-
 	if err != nil {
-		return fmt.Errorf("Error while file watcher")
+		return nil, fmt.Errorf("error while creating directory watcher: %v", err)
 	}
 
-	defer watcher.Close()
+	log.Info("Starting to watch directory:", directory)
 
 	go func() {
 		for {
 			select {
 			case event, ok := <-watcher.Events:
 				if !ok {
+					log.Error("Watcher events channel closed")
 					return
 				}
-				log.Println("event:", event)
+				log.Info("Event: ", event)
 				if event.Has(fsnotify.Write) {
-					log.Println("modified file:", event.Name)
+					log.Info("File modified: ", event.Name)
 				}
 			case err, ok := <-watcher.Errors:
 				if !ok {
+					log.Error("Watcher errors channel closed")
 					return
 				}
-				log.Println("error:", err)
+				log.Errorf("Watcher error: %v", err)
 			}
 		}
 	}()
 
 	err = watcher.Add(directory)
 	if err != nil {
-		log.Fatal(err)
+		watcher.Close() // Clean up if watcher.Add fails
+		return nil, fmt.Errorf("failed to add directory to watcher: %v", err)
 	}
 
-	return nil
+	return watcher, nil
 }


### PR DESCRIPTION
1. This adds watcher that watches over the chunk directory and simply `logs` the changes as of now.
1. To make docker build faster use the compiled binary instead of building one inside the container itself.